### PR TITLE
Use readable-stream instead of through2

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,22 +1,25 @@
 'use strict';
 
 var objectAssign = require('object-assign');
-var through = require('through2');
+var Transform = require('readable-stream/transform');
 
 module.exports = function (opts) {
 	opts = opts || {};
 
-	return through.obj(function (file, enc, cb) {
-		if (file.isNull()) {
-			cb(null, file);
-			return;
-		}
+	return new Transform({
+		objectMode: true,
+		transform: function (file, enc, cb) {
+			if (file.isNull()) {
+				cb(null, file);
+				return;
+			}
 
-		if (file.isStream()) {
-			cb(new Error('Streaming is not supported'));
-			return;
-		}
+			if (file.isStream()) {
+				cb(new Error('Streaming is not supported'));
+				return;
+			}
 
-		cb(null, objectAssign(file, opts));
+			cb(null, objectAssign(file, opts));
+		}
 	});
 };

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "keywords": [],
   "dependencies": {
     "object-assign": "^3.0.0",
-    "through2": "^0.6.3"
+    "readable-stream": "^2.0.0"
   },
   "devDependencies": {
     "ava": "^0.0.4",


### PR DESCRIPTION
This change reduces the package file size since [readable-stream](https://github.com/nodejs/readable-stream) is one of the dependencies of [through2](https://github.com/rvagg/through2). https://github.com/rvagg/through2/blob/v2.0.0/package.json#L23
